### PR TITLE
Fix updating quotes on user pages

### DIFF
--- a/src/modules/quote/user-quote.controller.ts
+++ b/src/modules/quote/user-quote.controller.ts
@@ -65,8 +65,7 @@ export class UserQuoteController {
             throw new UnauthorizedException('You are not authorized to update this quote');
 
         return await this.quoteService.update(quote.id, {
-            ...updateQuoteDto,
-            userId: req.user.id,
+            body: updateQuoteDto.body,
         });
     }
 


### PR DESCRIPTION
Fix updating quotes which was previously failing due to the manually specified nonexistent 'userId' join column.